### PR TITLE
feat: Use networkx v2.X API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.6", "3.7", "3.8"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - name: Checkout code

--- a/adage/controllerutils.py
+++ b/adage/controllerutils.py
@@ -55,7 +55,7 @@ def nodes_left_or_rule_applicable(adageobj):
     log.debug('nodes we could run: %s',nodes_we_could_run)
     if nodes_running_or_defined:
         log.debug('%s nodes that could be run or are running are left.',len(nodes_running_or_defined))
-        log.debug('nodes are: %s',[dag.node[n] for n in nodes_running_or_defined])
+        log.debug('nodes are: %s', [dag.nodes[n] for n in nodes_running_or_defined])
         return True
 
     if any(rule.applicable(adageobj) for rule in rules):

--- a/adage/graph.py
+++ b/adage/graph.py
@@ -18,7 +18,7 @@ class AdageDAG(nx.DiGraph):
         return node
 
     def addNode(self,nodeobj,depends_on = None):
-        self.add_node(nodeobj.identifier, {'nodeobj': nodeobj})
+        self.add_node(nodeobj.identifier, nodeobj=nodeobj)
         for parent in (depends_on or []):
             self.addEdge(parent,nodeobj)
 
@@ -29,7 +29,7 @@ class AdageDAG(nx.DiGraph):
         self.add_edge(fromobj.identifier,toobj.identifier)
 
     def getNode(self,ident):
-        return self.node[ident]['nodeobj']
+        return self.nodes[ident]['nodeobj']
 
     def getNodeByName(self,name, nodefilter = None):
         nodefilter = nodefilter or (lambda x: True)

--- a/adage/visualize.py
+++ b/adage/visualize.py
@@ -51,7 +51,7 @@ def colorize_graph_at_time(dag,time):
         style = 'filled' if visible else 'invis'
         dot_attr = {'label':'{} '.format(nodeobj.name), 'style':style, 'color': color}
 
-        colorized.add_node(node,dot_attr)
+        colorized.add_node(node, **dot_attr)
         for pre in dag.predecessors(node):
             colorized.add_edge(pre,node)
 

--- a/adage/visualize.py
+++ b/adage/visualize.py
@@ -65,7 +65,7 @@ def colorize_graph_at_time(dag,time):
 
 def save_dot(dotstring,filename,fileformat):
     with open(filename,'w') as dotoutputfile:
-        p = subprocess.Popen(['dot','-T{}'.format(fileformat),'-Gsize=18,12\!','-Gdpi=100'], stdout = dotoutputfile, stdin = subprocess.PIPE)
+        p = subprocess.Popen(['dot', '-T{}'.format(fileformat), r'-Gsize=18,12\!', '-Gdpi=100'], stdout = dotoutputfile, stdin = subprocess.PIPE)
         p.communicate(dotstring.encode('ascii'))
 
 def print_dag(dag,name,trackdir,time = None):

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     description = 'running dynamic DAG workflows',
     packages = find_packages(),
     install_requires = [
-        'networkx==1.11'
+        'networkx>=2.4'
     ],
     extras_require = {
         'develop': [


### PR DESCRIPTION
(Requires PR #17 to go in first.)

Part of addressing Issue #16
> 1. Upgrade the `networkx` dependency in `adage` to be `networkx>=2.4`
> 2. Fix anything that breaks with that 

* Set lower bound of `networkx` `v2.4` to allow for Python 3.9+
* Update to `networkx` `v2.0` API 
   - `.node` -> `.nodes`
   - Use kwargs instead of attr dicts
* Use raw strings to avoid: DeprecationWarning: invalid escape sequence \!
* Add Python 3.9 and 3.10 to testing