### PR TITLE
ci: Add TestPyPI and PyPI publishing workflow

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,0 +1,69 @@
+name: publish distributions
+
+on:
+  push:
+    branches:
+    - master
+    tags:
+      - v*
+  pull_request:
+    branches:
+    - master
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  build-and-publish:
+    name: Build and publish Python distro to (Test)PyPI
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.10"
+
+    - name: Install build, check-manifest, and twine
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install build check-manifest twine
+        python -m pip list
+
+    - name: Check MANIFEST
+      run: |
+        check-manifest
+
+    - name: Build a sdist and a wheel
+      run: |
+        python -m build .
+
+    - name: Verify the distribution
+      run: twine check dist/*
+
+    - name: List contents of sdist
+      run: python -m tarfile --list dist/adage-*.tar.gz
+
+    - name: List contents of wheel
+      run: python -m zipfile --list dist/adage-*.whl
+
+    - name: Publish distribution 📦 to Test PyPI
+      # publish to TestPyPI on tag events
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'yadage/adage'
+      uses: pypa/gh-action-pypi-publish@v1.4.2
+      with:
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/
+
+    - name: Publish distribution 📦 to PyPI
+      # publish to PyPI on releases
+      if: github.event_name == 'release' && github.event.action == 'published' && github.repository == 'yadage/adage'
+      uses: pypa/gh-action-pypi-publish@v1.4.2
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Final part of addressing Issue #16 (so resolves #16)

Add a GitHub actions workflow that will test building of an sdist and a wheel on PRs targeting `master` and push events to `master`. Additionally on pushes of tags build and deploy to TestPyPI for release validation, and on the publication of a GitHub release from a pushed tag (through the GitHub release website GUI) build and deploy to PyPI.

For this PR to work `adage` will need:
* [API tokens generated for TestPyPI and PyPI](https://pypi.org/help/#apitoken)
* The token for TestPyPI added as a GitHub secret named `TEST_PYPI_API_TOKEN`
* The token for PyPI added as a GitHub secret named `PYPI_API_TOKEN`