### PR TITLE
chore: Drop pydotplus as unused since networkx v2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 extras_require = {
     "develop": ["pyflakes", "pytest>=3.2.0", "pytest-cov>=2.5.1", "python-coveralls"],
     "viz": [
-        "pydot>=1.2.3",  # c.f. networkx PR 2272
+        "pydot>=1.2.3",  # c.f. https://github.com/networkx/networkx/pull/2272
         "pygraphviz>=1.0,!=1.8",  # c.f. https://github.com/pygraphviz/pygraphviz/issues/395
     ],
 }

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,8 @@ from setuptools import setup
 extras_require = {
     "develop": ["pyflakes", "pytest>=3.2.0", "pytest-cov>=2.5.1", "python-coveralls"],
     "viz": [
-        "pydot",
+        "pydot>=1.2.3",
         "pygraphviz>=1.0,!=1.8",  # c.f. https://github.com/pygraphviz/pygraphviz/issues/395
-        "pydotplus",
     ],
 }
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 extras_require = {
     "develop": ["pyflakes", "pytest>=3.2.0", "pytest-cov>=2.5.1", "python-coveralls"],
     "viz": [
-        "pydot>=1.2.3",
+        "pydot>=1.2.3",  # c.f. networkx PR 2272
         "pygraphviz>=1.0,!=1.8",  # c.f. https://github.com/pygraphviz/pygraphviz/issues/395
     ],
 }


### PR DESCRIPTION
Resolves #24

* Drop `pydotplus` from `viz` extra as it has unused by `adage` dependency `networkx` since `networkx` `v2.0`
   - c.f. https://github.com/networkx/networkx/pull/2272
* Set lower bound on `pydot` of `v1.2.3`

```
* Drop pydotplus from viz extra as it has unused by adage
dependency networkx since networkx v2.0
   - c.f. https://github.com/networkx/networkx/pull/2272
* Set lower bound on pydot of v1.2.3
   - c.f. https://github.com/networkx/networkx/pull/2272
   - > Support for the long-obsolete "pydotplus" fork has been
     > reverted back to the well-maintained parent "pydot" project...
     > All "nx_pydot" functions now explicitly require pydot >= 1.2.3,
     > which broke backwards API compatibility and resolved long-standing
     > Python 2.x issues. Sanity is restored.
```