### PR TITLE
fix: Exclude pygraphviz v1.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,11 @@ from setuptools import setup
 
 extras_require = {
     "develop": ["pyflakes", "pytest>=3.2.0", "pytest-cov>=2.5.1", "python-coveralls"],
-    "viz": ["pydot", "pygraphviz", "pydotplus"],
+    "viz": [
+        "pydot",
+        "pygraphviz!=1.8",  # c.f. https://github.com/pygraphviz/pygraphviz/issues/395
+        "pydotplus",
+    ],
 }
 
 setup(extras_require=extras_require)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ extras_require = {
     "develop": ["pyflakes", "pytest>=3.2.0", "pytest-cov>=2.5.1", "python-coveralls"],
     "viz": [
         "pydot",
-        "pygraphviz!=1.8",  # c.f. https://github.com/pygraphviz/pygraphviz/issues/395
+        "pygraphviz>=1.0,!=1.8",  # c.f. https://github.com/pygraphviz/pygraphviz/issues/395
         "pydotplus",
     ],
 }


### PR DESCRIPTION
* Exclude pygraphviz v1.8 for breaking installs on Python 3.7 and older
   - c.f. https://github.com/pygraphviz/pygraphviz/issues/395
* Set lower bound of pygraphviz v1.0
   - Untested, but realistic to ensure at least v1.0 API

```
* Exclude pygraphviz v1.8 for breaking installs on Python 3.7 and older
   - c.f. https://github.com/pygraphviz/pygraphviz/issues/395
* Set lower bound of pygraphviz v1.0
   - Untested, but realistic to ensure at least v1.0 API
```