### PR TITLE
ci: Update package publish workflow to v1.6.4

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -4,14 +4,25 @@ on:
   push:
     branches:
     - main
+  pull_request:
+    branches:
+    - main
     tags:
-      - v*
+    - v*
   pull_request:
     branches:
     - main
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      publish:
+        type: choice
+        description: 'Publish to TestPyPI?'
+        options:
+        - false
+        - true
+
 
 jobs:
   build-and-publish:
@@ -54,16 +65,21 @@ jobs:
       run: python -m zipfile --list dist/adage-*.whl
 
     - name: Publish distribution 📦 to Test PyPI
-      # publish to TestPyPI on tag events
-      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'yadage/adage'
-      uses: pypa/gh-action-pypi-publish@v1.4.2
+      # Publish to TestPyPI on tag events of if manually triggered
+      # Compare to 'true' string as booleans get turned into strings in the console
+      if: >-
+        (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'yadage/adage')
+        || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true' && github.repository == 'yadage/adage')
+      uses: pypa/gh-action-pypi-publish@v1.6.4
       with:
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         repository_url: https://test.pypi.org/legacy/
+        print_hash: true
 
     - name: Publish distribution 📦 to PyPI
       # publish to PyPI on releases
       if: github.event_name == 'release' && github.event.action == 'published' && github.repository == 'yadage/adage'
-      uses: pypa/gh-action-pypi-publish@v1.4.2
+      uses: pypa/gh-action-pypi-publish@v1.6.4
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}
+        print_hash: true


### PR DESCRIPTION
* Update pypa/gh-action-pypi-publish from v1.4.2 to v1.6.4

* Add publish to TestPyPI option